### PR TITLE
Add vanilla todo app

### DIFF
--- a/todo-app.css
+++ b/todo-app.css
@@ -1,3 +1,9 @@
 body {
   background-color: beige;
 }
+
+/* Styling for completed tasks using :checked pseudo class */
+.js-task-checkbox:checked + .js-task-label {
+  text-decoration: line-through;
+  opacity: 0.6;
+}

--- a/todo-app.html
+++ b/todo-app.html
@@ -19,15 +19,14 @@
       <button id="js-add-task-btn">Add task</button>
     </form>
 
-    <ol id="js-task-list">
-      <!-- <li>
-        <label>
-          <input type="checkbox" />
-          Learn flexbox
-        </label>
+    <ol id="js-task-list"></ol>
 
-        <button type="button">Remove</button>
-      </li> -->
-    </ol>
+    <template id="js-todo-template">
+      <li class="js-task-list-item">
+        <input type="checkbox" class="js-task-checkbox" />
+        <label class="js-task-label"></label>
+        <button class="js-remove-btn">Remove</button>
+      </li>
+    </template>
   </body>
 </html>

--- a/todo-app.js
+++ b/todo-app.js
@@ -2,45 +2,77 @@
 let inputEl = document.querySelector("#js-task-title");
 let addTaskButton = document.querySelector("#js-add-task-btn");
 let listEl = document.querySelector("#js-task-list");
-
-let taskTitle = "some task";
 let tasks = [];
+
+// fetch initial todos since we don't have a db connected
+async function fetchInitialTodos() {
+  try {
+    response = await fetch('https://dummyjson.com/todos?limit=5');
+    data = await response.json();
+    
+    // API gives a data in different format, so we need to map it to our tasks structure
+    tasks = data.todos.map(function(todo) {
+      return {
+        title: todo.todo,
+        isCompleted: todo.completed
+      };
+    });
+    
+    updateDom();
+  } catch (error) {
+    console.error('Failed to fetch todos:', error);
+  }
+}
+
+fetchInitialTodos();
 
 // event listeners (state updation)
 addTaskButton.addEventListener("click", function (event) {
   // stop the default form submission
   event.preventDefault();
 
+  if (inputEl.value.trim() === "") {
+    alert("Task title cannot be empty");
+    return;
+  }
+
   // update the state
   let newTask = {
     title: inputEl.value,
-    isCompeleted: false,
+    isCompleted: false,
   };
 
   tasks.unshift(newTask);
-
+  inputEl.value = "";
   updateDom();
 });
 
-// DOM updation (mapping state -> DOM)
+listEl.addEventListener("click", function(event) {
+  if (event.target.classList.contains("js-task-checkbox")) {
+    const taskIndex = Array.from(listEl.children).indexOf(event.target.closest("li"));
+    tasks[taskIndex].isCompleted = event.target.checked;
+  } else if (event.target.classList.contains("js-remove-btn")) {
+    const taskIndex = Array.from(listEl.children).indexOf(event.target.closest("li"));
+    tasks.splice(taskIndex, 1);
+    updateDom();
+  }
+});
 
+// DOM updation (mapping state -> DOM)
 function updateDom() {
   // map state to DOM
-
+  listEl.innerHTML = "";
+  const template = document.querySelector("#js-todo-template");
+  
   for (let i = 0; i < tasks.length; i++) {
-    const li = document.createElement("li");
-    const label = document.createElement("label");
-    const input = document.createElement("input");
-    input.type = "checkbox";
+    const clone = template.content.cloneNode(true);
+    
+    const input = clone.querySelector(".js-task-checkbox");
+    const label = clone.querySelector(".js-task-label");
+    
+    input.checked = tasks[i].isCompleted;
     label.textContent = tasks[i].title;
-    label.prepend(input);
-    const button = document.createElement("button");
-    button.textContent = "Remove";
-    li.append(label);
-    li.append(button);
-
-    console.log(li);
-
-    listEl.append(li);
+    
+    listEl.appendChild(clone);
   }
 }


### PR DESCRIPTION
HTML Changes:
- template tag was added, instead of creating HTML elements manually in JavaScript.

CSS Changes:
- Used `:checked pseudo class` to have strike through when checked while making it semi-transparent. 

JS Changes:
- On page load, [get](https://dummyjson.com/todos) dummy data to load the initial todo tasks 
- Add an alert when empty task title is added by the user.
- Add event delegation for listening checkbox changes
- Update `updateDom()` to update DOM with the help of template tag.

Screenshot:

<img width="1024" height="582" alt="image" src="https://github.com/user-attachments/assets/af9622ef-59e4-4b11-92a9-bcbd6f0b81d6" />
